### PR TITLE
Remove line about ISO standarts

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,6 @@
 	<li>Your YubiKey isn't ever going to work on a goat. It would kick your ass if you tried.</li>
         <li>If a goat takes a "dump" in the middle of the night, you take care of it when you damn well feel like it.</li>
         <li>Nobody will fire you for connecting "diskless goats" into a "goat server" instead of a mainframe goat and a bunch of cheap "dumb goats".</li>
-        <li>ISO is not publishing any standards about how you should be farming your goats.</li>
         <li>Counting from zero instead of one doesn't apply to anything goat farmers do and looks stupid. Hexadecimal is unheard of.</li>
         <li>When you sell a goat, you don't need to export it to a format that will be understood by the buyer's ancient goat-reading software.</li>
         <li>All your stuff will still work when you buy your 100th goat, and your 256th goat, and your 65,536th goat...</li>


### PR DESCRIPTION
It seems to me that this statement is not entirely true, since some published ISO standards also apply to goats.

Examples: https://www.iso.org/search.html?q=goat&hPP=10&idx=all_en&p=0 